### PR TITLE
Tests: Table.update(..) is not fully implemented 

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -2,6 +2,7 @@
 
 * #32 Upgrade to BQ 0.23 and update test API to match the new Bootique test API
 * #33 Support for binding java.time classes when inserting test data via Table
+* #36 Tests: Table.update(..) is not fully implemented 
 
 ## 0.14
 

--- a/bootique-jdbc-test/src/main/java/io/bootique/jdbc/test/Table.java
+++ b/bootique-jdbc-test/src/main/java/io/bootique/jdbc/test/Table.java
@@ -47,7 +47,7 @@ public class Table {
      * Update table statement
      *
      * @return {@link UpdateSetBuilder}
-     * @since 0.23
+     * @since 0.15
      */
     public UpdateSetBuilder updateSet() {
         StringBuilder sql = new StringBuilder();

--- a/bootique-jdbc-test/src/main/java/io/bootique/jdbc/test/Table.java
+++ b/bootique-jdbc-test/src/main/java/io/bootique/jdbc/test/Table.java
@@ -36,20 +36,13 @@ public class Table {
         return new Builder().channel(channel).name(name);
     }
 
-    public UpdateWhereBuilder update() {
-        StringBuilder sql = new StringBuilder();
-        sql.append("UPDATE ").append(quotationStrategy.quoted(name)).append(" SET ");
-        UpdatingSqlContext context = new UpdatingSqlContext(channel, quotationStrategy, sql, new ArrayList<>());
-        return new UpdateWhereBuilder(context);
-    }
-
     /**
      * Update table statement
      *
      * @return {@link UpdateSetBuilder}
      * @since 0.15
      */
-    public UpdateSetBuilder updateSet() {
+    public UpdateSetBuilder update() {
         StringBuilder sql = new StringBuilder();
         sql.append("UPDATE ").append(quotationStrategy.quoted(name)).append(" SET ");
         UpdatingSqlContext context = new UpdatingSqlContext(channel, quotationStrategy, sql, new ArrayList<>());

--- a/bootique-jdbc-test/src/main/java/io/bootique/jdbc/test/Table.java
+++ b/bootique-jdbc-test/src/main/java/io/bootique/jdbc/test/Table.java
@@ -43,6 +43,19 @@ public class Table {
         return new UpdateWhereBuilder(context);
     }
 
+    /**
+     * Update table statement
+     *
+     * @return {@link UpdateSetBuilder}
+     * @since 0.23
+     */
+    public UpdateSetBuilder updateSet() {
+        StringBuilder sql = new StringBuilder();
+        sql.append("UPDATE ").append(quotationStrategy.quoted(name)).append(" SET ");
+        UpdatingSqlContext context = new UpdatingSqlContext(channel, quotationStrategy, sql, new ArrayList<>());
+        return new UpdateSetBuilder(context);
+    }
+
     public UpdateWhereBuilder delete() {
 
         StringBuilder sql = new StringBuilder();

--- a/bootique-jdbc-test/src/main/java/io/bootique/jdbc/test/UpdateSetBuilder.java
+++ b/bootique-jdbc-test/src/main/java/io/bootique/jdbc/test/UpdateSetBuilder.java
@@ -1,19 +1,16 @@
 package io.bootique.jdbc.test;
 
-import java.util.List;
-
 public class UpdateSetBuilder {
 
     protected UpdatingSqlContext context;
-    protected List<Binding> bindings;
-    protected StringBuilder sqlBuffer;
     protected int setCount;
 
     protected UpdateSetBuilder(UpdatingSqlContext context) {
         this.context = context;
-        this.bindings = bindings;
-        this.sqlBuffer = sqlBuffer;
-        sqlBuffer.append(" SET ");
+    }
+
+    public int execute() {
+        return context.execute();
     }
 
     public UpdateSetBuilder set(String column, Object value) {
@@ -22,7 +19,7 @@ public class UpdateSetBuilder {
 
     public UpdateSetBuilder set(String column, Object value, int valueType) {
         if (setCount++ > 0) {
-            sqlBuffer.append(", ");
+            context.append(", ");
         }
 
         context.appendIdentifier(column).append(" = ?");

--- a/bootique-jdbc-test/src/main/java/io/bootique/jdbc/test/UpdatingSqlContext.java
+++ b/bootique-jdbc-test/src/main/java/io/bootique/jdbc/test/UpdatingSqlContext.java
@@ -38,6 +38,6 @@ public class UpdatingSqlContext {
     }
 
     public void addBinding(Column column, Object value) {
-        bindings.add(new Binding(column, value));
+        bindings.add(new Binding(column, channel.convert(value)));
     }
 }

--- a/bootique-jdbc-test/src/test/java/io/bootique/jdbc/test/TableIT.java
+++ b/bootique-jdbc-test/src/test/java/io/bootique/jdbc/test/TableIT.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 
 import java.sql.Date;
 import java.sql.Timestamp;
+import java.sql.Types;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -185,6 +186,46 @@ public class TableIT {
                 .values(3, 3, "2017-01-09", "2017-01-10 13:00:01")
                 .exec();
         assertEquals(3, T2.getRowCount());
+    }
+
+    @Test
+    public void testUpdate() {
+        assertEquals(0, T1.getRowCount());
+        T1.insert(1, "x", "y");
+        T1.updateSet()
+                .set("c1", 2, Types.INTEGER)
+                .set("c2", "a", Types.VARCHAR)
+                .set("c3", "b", Types.VARCHAR)
+                .execute();
+
+        List<Object[]> data = T1.select();
+        assertEquals(1, data.size());
+
+        Object[] row = data.get(0);
+        assertEquals(2, row[0]);
+        assertEquals("a", row[1]);
+        assertEquals("b", row[2]);
+    }
+
+    @Test
+    public void testUpdateColumns_OutOfOrder() {
+        assertEquals(0, T2.getRowCount());
+        T2.insert(1, 2, LocalDate.now(), null);
+
+        T2.updateSet()
+                .set("c3", LocalDate.parse("2018-01-09"), Types.DATE)
+                .set("c1", "3", Types.INTEGER)
+                .set("c2", 4, Types.INTEGER)
+                .execute();
+
+        List<Object[]> data = T2.select();
+        assertEquals(1, data.size());
+
+        Object[] row = data.get(0);
+        assertEquals(3, row[0]);
+        assertEquals(4, row[1]);
+        assertEquals(Date.valueOf("2018-01-09"), row[2]);
+        assertEquals(null, row[3]);
     }
 
 }

--- a/bootique-jdbc-test/src/test/java/io/bootique/jdbc/test/TableIT.java
+++ b/bootique-jdbc-test/src/test/java/io/bootique/jdbc/test/TableIT.java
@@ -192,7 +192,7 @@ public class TableIT {
     public void testUpdate() {
         assertEquals(0, T1.getRowCount());
         T1.insert(1, "x", "y");
-        T1.updateSet()
+        T1.update()
                 .set("c1", 2, Types.INTEGER)
                 .set("c2", "a", Types.VARCHAR)
                 .set("c3", "b", Types.VARCHAR)
@@ -212,10 +212,33 @@ public class TableIT {
         assertEquals(0, T2.getRowCount());
         T2.insert(1, 2, LocalDate.now(), null);
 
-        T2.updateSet()
+        T2.update()
                 .set("c3", LocalDate.parse("2018-01-09"), Types.DATE)
                 .set("c1", "3", Types.INTEGER)
                 .set("c2", 4, Types.INTEGER)
+                .execute();
+
+        List<Object[]> data = T2.select();
+        assertEquals(1, data.size());
+
+        Object[] row = data.get(0);
+        assertEquals(3, row[0]);
+        assertEquals(4, row[1]);
+        assertEquals(Date.valueOf("2018-01-09"), row[2]);
+        assertEquals(null, row[3]);
+    }
+
+    @Test
+    public void testUpdateColumns_Where() {
+        assertEquals(0, T2.getRowCount());
+        T2.insert(1, 0, LocalDate.now(), new Date(0));
+
+        T2.update()
+                .set("c3", LocalDate.parse("2018-01-09"), Types.DATE)
+                .set("c1", "3", Types.INTEGER)
+                .set("c2", 4, Types.INTEGER)
+                .set("c4", null, Types.TIMESTAMP)
+                .where("c1", 1)
                 .execute();
 
         List<Object[]> data = T2.select();


### PR DESCRIPTION
Ref: bootique/bootique-jdbc#36

New method  updateSet() has been introduced, the old one update() kept as a part of API.
